### PR TITLE
Initial support for regular expressions 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [instaparse "1.3.4"]
-                 [org.clojure/core.logic "0.8.7"]])
+                 [instaparse "1.4.1"]
+                 [org.clojure/core.logic "0.8.10"]])

--- a/src/instagenerate/core.clj
+++ b/src/instagenerate/core.clj
@@ -189,4 +189,4 @@ by the parser. Could be infinite."
                   (full-parseo (get grammar (:start-production instaparser)) grammar q pt)))
       (run (or n 1) [q]
            (fresh [pt]
-                  (full-parseo (get grammar (:start-production instaparser)) grammar q pt))))))
+                  (full-parseo (get grammar (:start-production instaparser)) grammar q pt))))))(declare instaparseo)

--- a/src/instagenerate/regexp.clj
+++ b/src/instagenerate/regexp.clj
@@ -1,0 +1,64 @@
+(ns instagenerate.regexp
+  (:refer-clojure :exclude [cat])
+  (:require [instaparse.combinators :refer :all]
+            [instaparse.core :as insta]
+            [clojure.pprint :refer [pprint]]))
+
+(defn altnt [& keys] (apply alt (map nt keys)))
+(defn hs [str] (hide (string-ci str)))
+
+(defn ranged [a b]
+  (map (comp str char) (range (int a) (inc (int b)))))
+
+(def characters
+  (concat
+   (ranged \A \Z)
+   (ranged \a \z)
+   (ranged \0 \9)
+   ["_" "$"]))
+
+(def regexp-map
+  {:regexp (cat  (nt :term) (star (cat (hs "|") (nt :term))))
+   :term   (star (nt :factor))
+   :factor (cat  (nt :base)
+                 (opt (alt (string "*")
+                           (string "?")
+                           (string "+"))))
+   :base   (alt (nt :char) (nt :grouped) (nt :escaped)
+                (nt :bracketed))
+   :grouped   (cat (hs "(") (nt :regexp) (hs ")"))
+   :bracketed (cat (hs "[") (star (altnt :range :char)) (hs "]"))
+   :range     (cat (nt :char) (hs "-") (nt :char)) 
+   :escaped (cat (hs  "\\") (nt :char))
+   :char (apply alt (map string characters))})
+
+(def parser
+  (insta/parser regexp-map :start :regexp))
+
+(def escaped
+  {"B" Epsilon
+   })
+(def transform
+  {:regexp alt
+   :term   cat
+   :factor
+   (fn
+     ([arg]   arg)
+     ([arg modifier]
+      (case modifier
+        "*" (star arg)
+        "?" (opt arg)
+        "+" (plus arg))))
+   :base    cat
+   :grouped cat
+   :escaped (fn [{c :string}] (escaped c))
+   :char    string
+   :bracketed alt
+   :range (fn [{a :string} {b :string}]
+            (apply alt (map string (ranged (first a) (first b)))))})
+
+(defn regexp->parser [s]
+  (as-> s $
+    (parser $)
+    (insta/transform transform $)
+    (insta/parser {:start $} :start :start)))

--- a/test/instagenerate/core_test.clj
+++ b/test/instagenerate/core_test.clj
@@ -1,7 +1,48 @@
 (ns instagenerate.core-test
-  (:use clojure.test
-        instagenerate.core))
+  (:require [clojure.test       :refer :all]
+            [clojure.core.logic :as l]
+            [instaparse.core    :as insta]
+            [instagenerate.core :as g]
+            [instagenerate.regexp :refer [regexp->parser]]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(def simple
+  (insta/parser "S = 'ab' C
+                 C = 'c'+"))
+
+(deftest example-test
+  (is (= (take 3 (l/run* [input output]
+                   (g/instaparseo simple input output)))
+         '([(\a \b \c) (:S "ab" (:C "c"))]
+           [(\a \b \c \c) (:S "ab" (:C "c" "c"))]
+           [(\a \b \c \c \c) (:S "ab" (:C "c" "c" "c"))]))))
+
+(def rp
+  (regexp->parser "abc?de[a-d]?"))
+
+(deftest regexp-test
+  (is (insta/failure? (rp "nope")))
+  (is (= (rp "abdea") [:start "a" "b" "d" "e" "a"]))
+  (is (= (rp "abcded") [:start "a" "b" "c" "d" "e" "d"]))
+  (is (= (rp "abcdea") [:start "a" "b" "c" "d" "e" "a"]))
+  (is (= (map (partial apply str) (g/generate-possible-strings rp))
+         '("abde"
+           "abcde"
+           "abdea"
+           "abcdea"
+           "abdeb"
+           "abcdeb"
+           "abdec"
+           "abcdec"
+           "abded"
+           "abcded"))))
+
+(def mixed
+  (insta/parser "S = #'ab' C
+                 C = #'c'+"))
+
+(deftest mixed-test
+  (is (= (take 3 (l/run* [input output]
+                   (g/instaparseo mixed input output)))
+         '([(\a \b \c) (:S "ab" (:C "c"))]
+           [(\a \b \c \c) (:S "ab" (:C "c" "c"))]
+           [(\a \b \c \c \c) (:S "ab" (:C "c" "c" "c"))]))))


### PR DESCRIPTION
By adding in a parser for regular expression syntax as well as
transforms that convert the parsed regular expression output into
instaparse combinators, we can use instagenerate on grammars that
contain regular expressions. This commit adds in some simple support for
the basics of regular experssions, as well as adding some tests.
